### PR TITLE
Stub for getting NFT metadata

### DIFF
--- a/server/Controllers/V1/NFT/NFTRoutes.ts
+++ b/server/Controllers/V1/NFT/NFTRoutes.ts
@@ -1,7 +1,20 @@
 import express, { Router } from "express";
+import { logInfo } from "../../../Config/Logger";
+import { getNFTMetadata } from "../../../Services/NFTService";
 
 const router = express.Router();
+router.get('/:id', (req, res) => {
+    const tokenId = req.params.id;
+    logInfo(`Getting metadata for tokenId=${tokenId}`);
+    const metadata = getNFTMetadata(tokenId);
+    logInfo(`Got metadata for tokenId=${tokenId} metadata=${JSON.stringify(metadata)}`);
 
+    if (!metadata) {
+        return res.status(404);
+    }
+
+    return res.json(metadata);
+})
 
 export default function registerNFTRoutes(r: Router) {
     r.use('/nft', router);

--- a/server/Models/NFT.ts
+++ b/server/Models/NFT.ts
@@ -1,0 +1,12 @@
+export interface NFTAttribute {
+    trait_type: string,
+    value: string
+}
+export interface NFT {
+    name: string,
+    description: string,
+    tokenId: number,
+    image: string,
+    external_url: string,
+    attributes: NFTAttribute[]
+}

--- a/server/Services/NFTService.ts
+++ b/server/Services/NFTService.ts
@@ -1,0 +1,14 @@
+import { NFT } from "../Models/NFT";
+
+const tempNft : NFT = {
+    name: "Project 4 NFT#2473",
+    description: "NFT for Project 4 of Encode May's Solidity Bootcamp",
+    tokenId: 2473,
+    image: "https://img.seadn.io/files/9b791356bc13e1fb3da2350aee28bc4e.png",
+    external_url: "https://project4.com",
+    attributes: [{"trait_type":"Background","value":"New Punk Blue"},{"trait_type":"Eyes","value":"Hypnotized"},{"trait_type":"Mouth","value":"Bored"},{"trait_type":"Hat","value":"Sushi Chef Headband"},{"trait_type":"Fur","value":"Golden Brown"}]
+};
+
+export function getNFTMetadata(_tokenId: string) : NFT {
+    return tempNft;
+}


### PR DESCRIPTION
Calling `http://localhost:<port>/v1/nft/:tokenId` will always return 
```
{
  "name": "Project 4 NFT#2473",
  "description": "NFT for Project 4 of Encode May's Solidity Bootcamp",
  "tokenId": 2473,
  "image": "https://img.seadn.io/files/9b791356bc13e1fb3da2350aee28bc4e.png",
  "external_url": "https://project4.com",
  "attributes": [
    {
      "trait_type": "Background",
      "value": "New Punk Blue"
    },
    {
      "trait_type": "Eyes",
      "value": "Hypnotized"
    },
    {
      "trait_type": "Mouth",
      "value": "Bored"
    },
    {
      "trait_type": "Hat",
      "value": "Sushi Chef Headband"
    },
    {
      "trait_type": "Fur",
      "value": "Golden Brown"
    }
  ]
}
```